### PR TITLE
use normalized macro name

### DIFF
--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -128,7 +128,7 @@ zend_module_entry hdrhistogram_module_entry = {
     PHP_RINIT(hdrhistogram),               /* Request init callback */
     PHP_RSHUTDOWN(hdrhistogram),           /* Request shutdown callback */
     PHP_MINFO(hdrhistogram),               /* Module info callback */
-    HDR_VERSION,
+    PHP_HDR_HISTOGRAM_VERSION,
     STANDARD_MODULE_PROPERTIES
 };
 

--- a/php_hdrhistogram.h
+++ b/php_hdrhistogram.h
@@ -5,7 +5,7 @@
 
 extern zend_module_entry hdrhistogram_module_entry;
 #define phpext_hdrhistogram_ptr &hdrhistogram_module_entry
-#define HDR_VERSION "0.2.0"
+#define PHP_HDR_HISTOGRAM_VERSION "0.3.0"
 
 PHP_MINIT_FUNCTION(hdrhistogram);
 PHP_MSHUTDOWN_FUNCTION(hdrhistogram);


### PR DESCRIPTION
Version 0.3.0 report as version 0.2.0 (this is a very common error).

This PR is not about fixing this (too late, version is now published), but to used normalized macro name, so it will be check during package upload, and will avoid future mistake.

More information, see: http://git.php.net/?p=web/pecl.git;a=blob;f=public_html/release-upload.php;h=681f14a47a5ba39f103bbc9b826847e072255f91;hb=HEAD#l93

Extension or project name are ok (so PHP_HDRHISTOGRAM_VERSION or PHP_HDR_HISTOGRAM_VERSION)

For now, as pecl is unable to check the version, only a warning should be displayed after upload.
