### PR TITLE
add all arginfo and fix PHP 8 compatibility

### DIFF
--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -7,6 +7,12 @@
 #include "hdr/hdr_histogram_log.h"
 #include "php_hdrhistogram.h"
 
+#if PHP_VERSION_ID < 80000
+#include "hdrhistogram_legacy_arginfo.h"
+#else
+#include "hdrhistogram_arginfo.h"
+#endif
+
 #define PHP_HDRHISTOGRAM_DESCRIPTOR_RES_NAME "hdr_histogram"
 
 static int le_hdrhistogram_descriptor;
@@ -14,24 +20,24 @@ static int le_hdrhistogram_iter_descriptor;
 
 #define strsize_t size_t
 
-static zend_always_inline void hdr_register_hdr_resource(zval *return_value, struct hdr_histogram* hdr TSRMLS_DC)
+static zend_always_inline void hdr_register_hdr_resource(zval *return_value, struct hdr_histogram* hdr)
 {
     ZVAL_RES(return_value, zend_register_resource(hdr, le_hdrhistogram_descriptor));
 }
 
-static zend_always_inline void hdr_register_iter_resource(zval *return_value, struct hdr_iter* iter TSRMLS_DC)
+static zend_always_inline void hdr_register_iter_resource(zval *return_value, struct hdr_iter* iter)
 {
     ZVAL_RES(return_value, zend_register_resource(iter, le_hdrhistogram_iter_descriptor));
 }
 
-static zend_always_inline struct hdr_histogram* hdr_fetch_resource(zval *res, zval *return_value TSRMLS_DC)
+static zend_always_inline struct hdr_histogram* hdr_fetch_resource(zval *res, zval *return_value)
 {
     struct hdr_histogram *hdr;
 
     return (struct hdr_histogram*)zend_fetch_resource(Z_RES_P(res), PHP_HDRHISTOGRAM_DESCRIPTOR_RES_NAME, le_hdrhistogram_descriptor);
 }
 
-static zend_always_inline struct hdr_iter* hdr_fetch_iterator(zval *res, zval *return_value TSRMLS_DC)
+static zend_always_inline struct hdr_iter* hdr_fetch_iterator(zval *res, zval *return_value)
 {
     struct hdr_iter *iterator;
 
@@ -48,37 +54,10 @@ static zend_always_inline zval* hdr_hash_index_find(HashTable *arr, zend_ulong h
     return zend_hash_index_find(arr, h);
 }
 
-zend_function_entry hdrhistogram_functions[] = {
-    PHP_FE(hdr_init, NULL)
-    PHP_FE(hdr_get_memory_size, NULL)
-    PHP_FE(hdr_record_value, NULL)
-    PHP_FE(hdr_record_values, NULL)
-    PHP_FE(hdr_record_corrected_value, NULL)
-    PHP_FE(hdr_mean, NULL)
-    PHP_FE(hdr_stddev, NULL)
-    PHP_FE(hdr_min, NULL)
-    PHP_FE(hdr_max, NULL)
-    PHP_FE(hdr_total_count, NULL)
-    PHP_FE(hdr_reset, NULL)
-    PHP_FE(hdr_count_at_value, NULL)
-    PHP_FE(hdr_value_at_percentile, NULL)
-    PHP_FE(hdr_add, NULL)
-    PHP_FE(hdr_merge_into, NULL)
-    PHP_FE(hdr_iter_init, NULL)
-    PHP_FE(hdr_iter_next, NULL)
-    PHP_FE(hdr_percentile_iter_init, NULL)
-    PHP_FE(hdr_percentile_iter_next, NULL)
-    PHP_FE(hdr_export, NULL)
-    PHP_FE(hdr_import, NULL)
-    PHP_FE(hdr_base64_encode, NULL)
-    PHP_FE(hdr_base64_decode, NULL)
-    { NULL, NULL, NULL }
-};
-
 zend_module_entry hdrhistogram_module_entry = {
     STANDARD_MODULE_HEADER,
     "hdrhistogram",
-    hdrhistogram_functions,                /* List of functions exposed */
+    ext_functions,                         /* List of functions exposed */
     PHP_MINIT(hdrhistogram),               /* Module init callback */
     PHP_MSHUTDOWN(hdrhistogram),           /* Module shutdown callback */
     PHP_RINIT(hdrhistogram),               /* Request init callback */
@@ -92,7 +71,7 @@ zend_module_entry hdrhistogram_module_entry = {
 ZEND_GET_MODULE(hdrhistogram)
 #endif
 
-static void php_hdrhistogram_descriptor_dtor(zend_resource *rsrc TSRMLS_DC)
+static void php_hdrhistogram_descriptor_dtor(zend_resource *rsrc)
 {
     free(rsrc->ptr);
 }
@@ -141,9 +120,9 @@ PHP_FUNCTION(hdr_init)
     long lowest_trackable_value, highest_trackable_value, significant_figures;
     int res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lll",
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "lll",
                 &lowest_trackable_value, &highest_trackable_value, &significant_figures) == FAILURE) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid arguments passed.");
+        php_error_docref(NULL, E_WARNING, "Invalid arguments passed.");
 
         RETURN_FALSE;
     }
@@ -151,9 +130,9 @@ PHP_FUNCTION(hdr_init)
     res = hdr_init(lowest_trackable_value, highest_trackable_value, significant_figures, &hdr);
 
     if (res == 0) {
-        hdr_register_hdr_resource(return_value, hdr TSRMLS_CC);
+        hdr_register_hdr_resource(return_value, hdr);
     } else if (res == EINVAL) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Lowest trackable value has to be >= 1.");
+        php_error_docref(NULL, E_WARNING, "Lowest trackable value has to be >= 1.");
 
         RETURN_FALSE;
     } else if (res == ENOMEM) {
@@ -166,11 +145,11 @@ PHP_FUNCTION(hdr_get_memory_size)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_LONG(hdr_get_memory_size(hdr));
 }
@@ -180,11 +159,11 @@ PHP_FUNCTION(hdr_mean)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_LONG(hdr_mean(hdr));
 }
@@ -194,11 +173,11 @@ PHP_FUNCTION(hdr_stddev)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_DOUBLE(hdr_stddev(hdr));
 }
@@ -209,11 +188,11 @@ PHP_FUNCTION(hdr_min)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_LONG(hdr_min(hdr));
 }
@@ -223,11 +202,11 @@ PHP_FUNCTION(hdr_max)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_LONG(hdr_max(hdr));
 }
@@ -237,11 +216,11 @@ PHP_FUNCTION(hdr_total_count)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_LONG(hdr->total_count);
 }
@@ -252,11 +231,11 @@ PHP_FUNCTION(hdr_record_value)
     zval *zhdr;
     long value;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &zhdr, &value) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &zhdr, &value) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     if (hdr_record_value(hdr, value) == 0) {
         RETURN_FALSE;
@@ -272,11 +251,11 @@ PHP_FUNCTION(hdr_record_values)
     long value;
     long count;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rll", &zhdr, &value, &count) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rll", &zhdr, &value, &count) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     if (hdr_record_values(hdr, value, count) == 0) {
         RETURN_FALSE;
@@ -292,11 +271,11 @@ PHP_FUNCTION(hdr_record_corrected_value)
     long value;
     long expected_interval;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rll", &zhdr, &value, &expected_interval) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rll", &zhdr, &value, &expected_interval) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     hdr_record_corrected_value(hdr, value, expected_interval);
 }
@@ -306,11 +285,11 @@ PHP_FUNCTION(hdr_reset)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     hdr_reset(hdr);
 }
@@ -321,11 +300,11 @@ PHP_FUNCTION(hdr_count_at_value)
     zval *zhdr;
     long value;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &zhdr, &value) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &zhdr, &value) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_LONG(hdr_count_at_value(hdr, value));
 }
@@ -336,11 +315,11 @@ PHP_FUNCTION(hdr_value_at_percentile)
     zval *zhdr;
     double percentile;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rd", &zhdr, &percentile) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rd", &zhdr, &percentile) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     RETURN_LONG(hdr_value_at_percentile(hdr, percentile));
 }
@@ -351,12 +330,12 @@ PHP_FUNCTION(hdr_add)
     zval *a, *b;
     int res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rr", &a, &b) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rr", &a, &b) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdra = hdr_fetch_resource(a, return_value TSRMLS_CC);
-    hdrb = hdr_fetch_resource(b, return_value TSRMLS_CC);
+    hdra = hdr_fetch_resource(a, return_value);
+    hdrb = hdr_fetch_resource(b, return_value);
 
     res = hdr_init(hdra->lowest_trackable_value, hdra->highest_trackable_value, hdra->significant_figures, &hdr_new);
 
@@ -364,9 +343,9 @@ PHP_FUNCTION(hdr_add)
     hdr_add(hdr_new, hdrb);
 
     if (res == 0) {
-        hdr_register_hdr_resource(return_value, hdr_new TSRMLS_CC);
+        hdr_register_hdr_resource(return_value, hdr_new);
     } else if (res == EINVAL) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Lowest trackable value has to be >= 1.");
+        php_error_docref(NULL, E_WARNING, "Lowest trackable value has to be >= 1.");
 
         RETURN_FALSE;
     } else if (res == ENOMEM) {
@@ -379,12 +358,12 @@ PHP_FUNCTION(hdr_merge_into)
     struct hdr_histogram *hdra, *hdrb;
     zval *a, *b;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rr", &a, &b) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rr", &a, &b) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdra = hdr_fetch_resource(a, return_value TSRMLS_CC);
-    hdrb = hdr_fetch_resource(b, return_value TSRMLS_CC);
+    hdra = hdr_fetch_resource(a, return_value);
+    hdrb = hdr_fetch_resource(b, return_value);
 
     RETURN_LONG(hdr_add(hdra, hdrb));
 }
@@ -395,16 +374,16 @@ PHP_FUNCTION(hdr_iter_init)
     struct hdr_histogram *hdr;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     iterator = malloc(sizeof(struct hdr_iter));
     hdr_iter_init(iterator, hdr);
 
-    hdr_register_iter_resource(return_value, iterator TSRMLS_CC);
+    hdr_register_iter_resource(return_value, iterator);
 }
 
 PHP_FUNCTION(hdr_percentile_iter_init)
@@ -414,16 +393,16 @@ PHP_FUNCTION(hdr_percentile_iter_init)
     zval *zhdr;
     long ticks_per_half_distance;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &zhdr, &ticks_per_half_distance) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &zhdr, &ticks_per_half_distance) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     iterator = malloc(sizeof(struct hdr_iter));
     hdr_iter_percentile_init(iterator, hdr, ticks_per_half_distance);
 
-    hdr_register_iter_resource(return_value, iterator TSRMLS_CC);
+    hdr_register_iter_resource(return_value, iterator);
 }
 
 PHP_FUNCTION(hdr_iter_next)
@@ -431,11 +410,11 @@ PHP_FUNCTION(hdr_iter_next)
     struct hdr_iter *iterator;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    iterator = hdr_fetch_iterator(zhdr, return_value TSRMLS_CC);
+    iterator = hdr_fetch_iterator(zhdr, return_value);
 
     if (hdr_iter_next(iterator)) {
         array_init(return_value);
@@ -453,11 +432,11 @@ PHP_FUNCTION(hdr_percentile_iter_next)
     struct hdr_iter *iterator;
     zval *zhdr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    iterator = hdr_fetch_iterator(zhdr, return_value TSRMLS_CC);
+    iterator = hdr_fetch_iterator(zhdr, return_value);
 
     if (hdr_iter_next(iterator)) {
         array_init(return_value);
@@ -483,11 +462,11 @@ PHP_FUNCTION(hdr_export)
     int found = 0;
     long skipped = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     array_init(return_value);
 
@@ -531,7 +510,7 @@ PHP_FUNCTION(hdr_import)
     int res, count;
     zend_ulong i, bucket, skipped;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &import) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &import) == FAILURE) {
         RETURN_FALSE;
     }
 
@@ -542,7 +521,7 @@ PHP_FUNCTION(hdr_import)
     }
 
     if (lowest_trackable_value <= 0) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "lowest_trackable_value (ltv) must be >= 1.");
+        php_error_docref(NULL, E_WARNING, "lowest_trackable_value (ltv) must be >= 1.");
         RETURN_FALSE;
     }
 
@@ -553,7 +532,7 @@ PHP_FUNCTION(hdr_import)
     }
 
     if (highest_trackable_value <= 0) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "highest_trackable_value (htv) must be >= 1.");
+        php_error_docref(NULL, E_WARNING, "highest_trackable_value (htv) must be >= 1.");
         RETURN_FALSE;
     }
 
@@ -564,7 +543,7 @@ PHP_FUNCTION(hdr_import)
     }
 
     if (significant_figures <= 0 || significant_figures > 3) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "significant_figures (sf) must be 1, 2, or 3.");
+        php_error_docref(NULL, E_WARNING, "significant_figures (sf) must be 1, 2, or 3.");
         RETURN_FALSE;
     }
 
@@ -575,7 +554,7 @@ PHP_FUNCTION(hdr_import)
     }
 
     if (skipped < 0 || lowest_trackable_value < 1 || highest_trackable_value < lowest_trackable_value || significant_figures < 1) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid values for ltv, htv, sf or sk keys given.");
+        php_error_docref(NULL, E_WARNING, "Invalid values for ltv, htv, sf or sk keys given.");
         RETURN_FALSE;
     }
 
@@ -587,9 +566,9 @@ PHP_FUNCTION(hdr_import)
         res = hdr_init(lowest_trackable_value, highest_trackable_value, significant_figures, &hdr);
 
         if (res == 0) {
-            hdr_register_hdr_resource(return_value, hdr TSRMLS_CC);
+            hdr_register_hdr_resource(return_value, hdr);
         } else if (res == EINVAL) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING, "Lowest trackable value has to be >= 1.");
+            php_error_docref(NULL, E_WARNING, "Lowest trackable value has to be >= 1.");
 
             RETURN_FALSE;
         } else if (res == ENOMEM) {
@@ -627,9 +606,9 @@ PHP_FUNCTION(hdr_import)
         res = hdr_init(lowest_trackable_value, highest_trackable_value, significant_figures, &hdr);
 
         if (res == 0) {
-            hdr_register_hdr_resource(return_value, hdr TSRMLS_CC);
+            hdr_register_hdr_resource(return_value, hdr);
         } else if (res == EINVAL) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING, "Lowest trackable value has to be >= 1.");
+            php_error_docref(NULL, E_WARNING, "Lowest trackable value has to be >= 1.");
 
             RETURN_FALSE;
         } else if (res == ENOMEM) {
@@ -668,9 +647,9 @@ PHP_FUNCTION(hdr_import)
         res = hdr_init(lowest_trackable_value, highest_trackable_value, significant_figures, &hdr);
 
         if (res == 0) {
-            hdr_register_hdr_resource(return_value, hdr TSRMLS_CC);
+            hdr_register_hdr_resource(return_value, hdr);
         } else if (res == EINVAL) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING, "Lowest trackable value has to be >= 1.");
+            php_error_docref(NULL, E_WARNING, "Lowest trackable value has to be >= 1.");
 
             RETURN_FALSE;
         } else if (res == ENOMEM) {
@@ -694,7 +673,7 @@ PHP_FUNCTION(hdr_import)
         hdr->normalizing_index_offset = 0;
         hdr->conversion_ratio = 1.0;
     } else {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Missing counts (c) or bucket (b) key or not arrays.");
+        php_error_docref(NULL, E_WARNING, "Missing counts (c) or bucket (b) key or not arrays.");
         RETURN_FALSE;
     }
 }
@@ -705,14 +684,14 @@ PHP_FUNCTION(hdr_base64_encode)
     zval *zhdr;
     char *result = NULL;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zhdr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zhdr) == FAILURE) {
         RETURN_FALSE;
     }
 
-    hdr = hdr_fetch_resource(zhdr, return_value TSRMLS_CC);
+    hdr = hdr_fetch_resource(zhdr, return_value);
 
     if (hdr_log_encode(hdr, &result) != 0) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot encode histogram");
+        php_error_docref(NULL, E_WARNING, "Cannot encode histogram");
 
         RETURN_FALSE;
     }
@@ -726,15 +705,15 @@ PHP_FUNCTION(hdr_base64_decode)
     char *data = NULL;
     strsize_t data_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &data, &data_len) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &data, &data_len) == FAILURE) {
         RETURN_FALSE;
     }
 
     if (hdr_log_decode(&hdr, data, data_len) != 0) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot decode histogram");
+        php_error_docref(NULL, E_WARNING, "Cannot decode histogram");
 
         RETURN_FALSE;
     }
 
-    hdr_register_hdr_resource(return_value, hdr TSRMLS_CC);
+    hdr_register_hdr_resource(return_value, hdr);
 }

--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -136,7 +136,9 @@ PHP_FUNCTION(hdr_init)
 
         RETURN_FALSE;
     } else if (res == ENOMEM) {
-        perror("Memory error in hdr_init allocation.");
+        php_error_docref(NULL, E_WARNING, "Memory error in hdr_init allocation.");
+
+        RETURN_FALSE;
     }
 }
 
@@ -277,7 +279,10 @@ PHP_FUNCTION(hdr_record_corrected_value)
 
     hdr = hdr_fetch_resource(zhdr, return_value);
 
-    hdr_record_corrected_value(hdr, value, expected_interval);
+    if (hdr_record_corrected_value(hdr, value, expected_interval)) {
+        RETURN_TRUE;
+    }
+    RETURN_FALSE;
 }
 
 PHP_FUNCTION(hdr_reset)
@@ -349,7 +354,9 @@ PHP_FUNCTION(hdr_add)
 
         RETURN_FALSE;
     } else if (res == ENOMEM) {
-        perror("Memory error in hdr_init allocation.");
+        php_error_docref(NULL, E_WARNING, "Memory error in hdr_init allocation.");
+
+        RETURN_FALSE;
     }
 }
 
@@ -572,7 +579,9 @@ PHP_FUNCTION(hdr_import)
 
             RETURN_FALSE;
         } else if (res == ENOMEM) {
-            perror("Memory error in hdr_init allocation.");
+            php_error_docref(NULL, E_WARNING, "Memory error in hdr_init allocation.");
+
+            RETURN_FALSE;
         }
 
         zend_string *key;
@@ -612,7 +621,9 @@ PHP_FUNCTION(hdr_import)
 
             RETURN_FALSE;
         } else if (res == ENOMEM) {
-            perror("Memory error in hdr_init allocation.");
+            php_error_docref(NULL, E_WARNING, "Memory error in hdr_init allocation.");
+
+            RETURN_FALSE;
         }
 
         for (i = 0; i < skipped; i++) {
@@ -653,7 +664,9 @@ PHP_FUNCTION(hdr_import)
 
             RETURN_FALSE;
         } else if (res == ENOMEM) {
-            perror("Memory error in hdr_init allocation.");
+            php_error_docref(NULL, E_WARNING, "Memory error in hdr_init allocation.");
+
+            RETURN_FALSE;
         }
 
         zend_string *key;

--- a/hdrhistogram.stub.php
+++ b/hdrhistogram.stub.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+/**
+ * @return resource|false
+ */
+function hdr_init(int $lowest_trackable_value, int $highest_trackable_value, int $significant_figures) {}
+
+/**
+ * @param resource $hdr
+ */
+function hdr_get_memory_size($hdr): int {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_record_value($hdr, int $value): bool {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_record_values($hdr, int $value, int $count): bool {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_record_corrected_value($hdr, int $value, int $expected_interval): void {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_mean($hdr): int {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_stddev($hdr): float {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_min($hdr): int {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_max($hdr): int {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_total_count($hdr): int {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_reset($hdr): void {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_count_at_value($hdr, int $value): int {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_value_at_percentile($hdr, float $percentile): int {};
+
+/**
+ * @param resource $hdr1
+ * @param resource $hdr2
+ * @return resource|false
+ */
+function hdr_add($hdr1, $hdr2) {};
+
+/**
+ * @param resource $hdr1
+ * @param resource $hdr2
+ */
+function hdr_merge_into($hdr1, $hdr2): int {};
+
+/**
+ * @param resource $hdr
+ * @return resource|false
+ */
+function hdr_iter_init($hdr) {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_iter_next($hdr): false|Array {};
+
+/**
+ * @param resource $hdr
+ * @return resource|false
+ */
+function hdr_percentile_iter_init($hdr, int $ticks_per_half_distance) {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_percentile_iter_next($hdr): false|Array {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_export($hdr): Array {};
+
+/**
+ * @return resource|false
+ */
+function hdr_import(Array $import) {};
+
+/**
+ * @param resource $hdr
+ */
+function hdr_base64_encode($hdr): false|string {};
+
+/**
+ * @return resource|false
+ */
+function hdr_base64_decode(string $data) {};
+

--- a/hdrhistogram.stub.php
+++ b/hdrhistogram.stub.php
@@ -28,7 +28,7 @@ function hdr_record_values($hdr, int $value, int $count): bool {};
 /**
  * @param resource $hdr
  */
-function hdr_record_corrected_value($hdr, int $value, int $expected_interval): void {};
+function hdr_record_corrected_value($hdr, int $value, int $expected_interval): bool {};
 
 /**
  * @param resource $hdr

--- a/hdrhistogram_arginfo.h
+++ b/hdrhistogram_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 195b1ceef170a9dd44acc536ff6ae157b79648be */
+ * Stub hash: abeaa5bc3b04ddf09db9de6645b72260090df7c3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_init, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, lowest_trackable_value, IS_LONG, 0)
@@ -22,7 +22,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_record_values, 0, 3, _IS_BOO
 	ZEND_ARG_TYPE_INFO(0, count, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_record_corrected_value, 0, 3, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_record_corrected_value, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, hdr)
 	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, expected_interval, IS_LONG, 0)

--- a/hdrhistogram_arginfo.h
+++ b/hdrhistogram_arginfo.h
@@ -1,0 +1,149 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 195b1ceef170a9dd44acc536ff6ae157b79648be */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_init, 0, 0, 3)
+	ZEND_ARG_TYPE_INFO(0, lowest_trackable_value, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, highest_trackable_value, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, significant_figures, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_get_memory_size, 0, 1, IS_LONG, 0)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_record_value, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_record_values, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, count, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_record_corrected_value, 0, 3, IS_VOID, 0)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, expected_interval, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_hdr_mean arginfo_hdr_get_memory_size
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_stddev, 0, 1, IS_DOUBLE, 0)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+#define arginfo_hdr_min arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_max arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_total_count arginfo_hdr_get_memory_size
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_reset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_count_at_value, 0, 2, IS_LONG, 0)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_value_at_percentile, 0, 2, IS_LONG, 0)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_TYPE_INFO(0, percentile, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_add, 0, 0, 2)
+	ZEND_ARG_INFO(0, hdr1)
+	ZEND_ARG_INFO(0, hdr2)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_merge_into, 0, 2, IS_LONG, 0)
+	ZEND_ARG_INFO(0, hdr1)
+	ZEND_ARG_INFO(0, hdr2)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_iter_init, 0, 0, 1)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_hdr_iter_next, 0, 1, MAY_BE_FALSE|MAY_BE_ARRAY)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_percentile_iter_init, 0, 0, 2)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_TYPE_INFO(0, ticks_per_half_distance, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_hdr_percentile_iter_next arginfo_hdr_iter_next
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hdr_export, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_import, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, import, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_hdr_base64_encode, 0, 1, MAY_BE_FALSE|MAY_BE_STRING)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_base64_decode, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(hdr_init);
+ZEND_FUNCTION(hdr_get_memory_size);
+ZEND_FUNCTION(hdr_record_value);
+ZEND_FUNCTION(hdr_record_values);
+ZEND_FUNCTION(hdr_record_corrected_value);
+ZEND_FUNCTION(hdr_mean);
+ZEND_FUNCTION(hdr_stddev);
+ZEND_FUNCTION(hdr_min);
+ZEND_FUNCTION(hdr_max);
+ZEND_FUNCTION(hdr_total_count);
+ZEND_FUNCTION(hdr_reset);
+ZEND_FUNCTION(hdr_count_at_value);
+ZEND_FUNCTION(hdr_value_at_percentile);
+ZEND_FUNCTION(hdr_add);
+ZEND_FUNCTION(hdr_merge_into);
+ZEND_FUNCTION(hdr_iter_init);
+ZEND_FUNCTION(hdr_iter_next);
+ZEND_FUNCTION(hdr_percentile_iter_init);
+ZEND_FUNCTION(hdr_percentile_iter_next);
+ZEND_FUNCTION(hdr_export);
+ZEND_FUNCTION(hdr_import);
+ZEND_FUNCTION(hdr_base64_encode);
+ZEND_FUNCTION(hdr_base64_decode);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(hdr_init, arginfo_hdr_init)
+	ZEND_FE(hdr_get_memory_size, arginfo_hdr_get_memory_size)
+	ZEND_FE(hdr_record_value, arginfo_hdr_record_value)
+	ZEND_FE(hdr_record_values, arginfo_hdr_record_values)
+	ZEND_FE(hdr_record_corrected_value, arginfo_hdr_record_corrected_value)
+	ZEND_FE(hdr_mean, arginfo_hdr_mean)
+	ZEND_FE(hdr_stddev, arginfo_hdr_stddev)
+	ZEND_FE(hdr_min, arginfo_hdr_min)
+	ZEND_FE(hdr_max, arginfo_hdr_max)
+	ZEND_FE(hdr_total_count, arginfo_hdr_total_count)
+	ZEND_FE(hdr_reset, arginfo_hdr_reset)
+	ZEND_FE(hdr_count_at_value, arginfo_hdr_count_at_value)
+	ZEND_FE(hdr_value_at_percentile, arginfo_hdr_value_at_percentile)
+	ZEND_FE(hdr_add, arginfo_hdr_add)
+	ZEND_FE(hdr_merge_into, arginfo_hdr_merge_into)
+	ZEND_FE(hdr_iter_init, arginfo_hdr_iter_init)
+	ZEND_FE(hdr_iter_next, arginfo_hdr_iter_next)
+	ZEND_FE(hdr_percentile_iter_init, arginfo_hdr_percentile_iter_init)
+	ZEND_FE(hdr_percentile_iter_next, arginfo_hdr_percentile_iter_next)
+	ZEND_FE(hdr_export, arginfo_hdr_export)
+	ZEND_FE(hdr_import, arginfo_hdr_import)
+	ZEND_FE(hdr_base64_encode, arginfo_hdr_base64_encode)
+	ZEND_FE(hdr_base64_decode, arginfo_hdr_base64_decode)
+	ZEND_FE_END
+};

--- a/hdrhistogram_legacy_arginfo.h
+++ b/hdrhistogram_legacy_arginfo.h
@@ -1,0 +1,131 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 195b1ceef170a9dd44acc536ff6ae157b79648be */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_init, 0, 0, 3)
+	ZEND_ARG_INFO(0, lowest_trackable_value)
+	ZEND_ARG_INFO(0, highest_trackable_value)
+	ZEND_ARG_INFO(0, significant_figures)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_get_memory_size, 0, 0, 1)
+	ZEND_ARG_INFO(0, hdr)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_record_value, 0, 0, 2)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_record_values, 0, 0, 3)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_INFO(0, value)
+	ZEND_ARG_INFO(0, count)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_record_corrected_value, 0, 0, 3)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_INFO(0, value)
+	ZEND_ARG_INFO(0, expected_interval)
+ZEND_END_ARG_INFO()
+
+#define arginfo_hdr_mean arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_stddev arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_min arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_max arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_total_count arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_reset arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_count_at_value arginfo_hdr_record_value
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_value_at_percentile, 0, 0, 2)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_INFO(0, percentile)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_add, 0, 0, 2)
+	ZEND_ARG_INFO(0, hdr1)
+	ZEND_ARG_INFO(0, hdr2)
+ZEND_END_ARG_INFO()
+
+#define arginfo_hdr_merge_into arginfo_hdr_add
+
+#define arginfo_hdr_iter_init arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_iter_next arginfo_hdr_get_memory_size
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_percentile_iter_init, 0, 0, 2)
+	ZEND_ARG_INFO(0, hdr)
+	ZEND_ARG_INFO(0, ticks_per_half_distance)
+ZEND_END_ARG_INFO()
+
+#define arginfo_hdr_percentile_iter_next arginfo_hdr_get_memory_size
+
+#define arginfo_hdr_export arginfo_hdr_get_memory_size
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_import, 0, 0, 1)
+	ZEND_ARG_INFO(0, import)
+ZEND_END_ARG_INFO()
+
+#define arginfo_hdr_base64_encode arginfo_hdr_get_memory_size
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_base64_decode, 0, 0, 1)
+	ZEND_ARG_INFO(0, data)
+ZEND_END_ARG_INFO()
+
+
+ZEND_FUNCTION(hdr_init);
+ZEND_FUNCTION(hdr_get_memory_size);
+ZEND_FUNCTION(hdr_record_value);
+ZEND_FUNCTION(hdr_record_values);
+ZEND_FUNCTION(hdr_record_corrected_value);
+ZEND_FUNCTION(hdr_mean);
+ZEND_FUNCTION(hdr_stddev);
+ZEND_FUNCTION(hdr_min);
+ZEND_FUNCTION(hdr_max);
+ZEND_FUNCTION(hdr_total_count);
+ZEND_FUNCTION(hdr_reset);
+ZEND_FUNCTION(hdr_count_at_value);
+ZEND_FUNCTION(hdr_value_at_percentile);
+ZEND_FUNCTION(hdr_add);
+ZEND_FUNCTION(hdr_merge_into);
+ZEND_FUNCTION(hdr_iter_init);
+ZEND_FUNCTION(hdr_iter_next);
+ZEND_FUNCTION(hdr_percentile_iter_init);
+ZEND_FUNCTION(hdr_percentile_iter_next);
+ZEND_FUNCTION(hdr_export);
+ZEND_FUNCTION(hdr_import);
+ZEND_FUNCTION(hdr_base64_encode);
+ZEND_FUNCTION(hdr_base64_decode);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(hdr_init, arginfo_hdr_init)
+	ZEND_FE(hdr_get_memory_size, arginfo_hdr_get_memory_size)
+	ZEND_FE(hdr_record_value, arginfo_hdr_record_value)
+	ZEND_FE(hdr_record_values, arginfo_hdr_record_values)
+	ZEND_FE(hdr_record_corrected_value, arginfo_hdr_record_corrected_value)
+	ZEND_FE(hdr_mean, arginfo_hdr_mean)
+	ZEND_FE(hdr_stddev, arginfo_hdr_stddev)
+	ZEND_FE(hdr_min, arginfo_hdr_min)
+	ZEND_FE(hdr_max, arginfo_hdr_max)
+	ZEND_FE(hdr_total_count, arginfo_hdr_total_count)
+	ZEND_FE(hdr_reset, arginfo_hdr_reset)
+	ZEND_FE(hdr_count_at_value, arginfo_hdr_count_at_value)
+	ZEND_FE(hdr_value_at_percentile, arginfo_hdr_value_at_percentile)
+	ZEND_FE(hdr_add, arginfo_hdr_add)
+	ZEND_FE(hdr_merge_into, arginfo_hdr_merge_into)
+	ZEND_FE(hdr_iter_init, arginfo_hdr_iter_init)
+	ZEND_FE(hdr_iter_next, arginfo_hdr_iter_next)
+	ZEND_FE(hdr_percentile_iter_init, arginfo_hdr_percentile_iter_init)
+	ZEND_FE(hdr_percentile_iter_next, arginfo_hdr_percentile_iter_next)
+	ZEND_FE(hdr_export, arginfo_hdr_export)
+	ZEND_FE(hdr_import, arginfo_hdr_import)
+	ZEND_FE(hdr_base64_encode, arginfo_hdr_base64_encode)
+	ZEND_FE(hdr_base64_decode, arginfo_hdr_base64_decode)
+	ZEND_FE_END
+};

--- a/hdrhistogram_legacy_arginfo.h
+++ b/hdrhistogram_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 195b1ceef170a9dd44acc536ff6ae157b79648be */
+ * Stub hash: abeaa5bc3b04ddf09db9de6645b72260090df7c3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_hdr_init, 0, 0, 3)
 	ZEND_ARG_INFO(0, lowest_trackable_value)

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,9 @@
    <file name="config.m4"    role="src" />
    <file name="php_hdrhistogram.h" role="src" />
    <file name="hdrhistogram.c" role="src" />
+   <file name="hdrhistogram.stub.php" role="src" />
+   <file name="hdrhistogram_arginfo.h" role="src" />
+   <file name="hdrhistogram_legacy_arginfo.h" role="src" />
    <file name="README.md" role="doc" />
    <file name="LICENSE" role="doc" />
    <dir name="tests">
@@ -40,9 +43,12 @@
     <file name="hdrhistogram_006.phpt" role="test" />
     <file name="hdrhistogram_007.phpt" role="test" />
     <file name="hdrhistogram_008.phpt" role="test" />
+    <file name="hdrhistogram_009.phpt" role="test" />
+    <file name="hdrhistogram_009_php8.phpt" role="test" />
     <file name="hdrhistogram_010.phpt" role="test" />
     <file name="hdrhistogram_011.phpt" role="test" />
     <file name="hdrhistogram_012.phpt" role="test" />
+    <file name="hdrhistogram_012_php8.phpt" role="test" />
     <file name="hdrhistogram_013.phpt" role="test" />
     <file name="hdrhistogram_014.phpt" role="test" />
     <file name="hdrhistogram_015.phpt" role="test" />

--- a/tests/hdrhistogram_009_php8.phpt
+++ b/tests/hdrhistogram_009_php8.phpt
@@ -2,7 +2,7 @@
 hdrhistogram: Base64 Encode/Decode
 --SKIPIF--
 <?php
-if (PHP_VERSION_ID >= 80000) die("skip PHP < 8 only");
+if (PHP_VERSION_ID < 80000) die("skip PHP 8 only");
 ?>
 --FILE--
 <?php
@@ -26,7 +26,11 @@ while ($data = hdr_iter_next($iterator)) {
 }
 echo "Total: $total\n";
 
-echo hdr_base64_encode("foo");
+try {
+    echo hdr_base64_encode("foo");
+} catch (TypeError $e) {
+	echo $e->getMessage()."\n";
+}
 echo hdr_base64_decode("foo");
 
 echo hdr_max(hdr_base64_decode(hdr_base64_encode(hdr_init(1, 100, 1))));
@@ -89,8 +93,7 @@ echo hdr_max(hdr_base64_decode(hdr_base64_encode(hdr_init(1, 100, 1))));
 92: 4
 96: 4
 Total: 100
+hdr_base64_encode(): Argument #1 ($hdr) must be of type resource, string given
 
-Warning: hdr_base64_encode() expects parameter 1 to be resource, string given in %s on line 22
-
-Warning: hdr_base64_decode(): Cannot decode histogram in %s on line 23
+Warning: hdr_base64_decode(): Cannot decode histogram in %s on line %d
 0

--- a/tests/hdrhistogram_012.phpt
+++ b/tests/hdrhistogram_012.phpt
@@ -1,5 +1,9 @@
 --TEST--
 HdrHistogram: hdr_import Error Handling
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80000) die("skip PHP < 8 only");
+?>
 --FILE--
 <?php
 

--- a/tests/hdrhistogram_012_php8.phpt
+++ b/tests/hdrhistogram_012_php8.phpt
@@ -1,0 +1,40 @@
+--TEST--
+HdrHistogram: hdr_import Error Handling
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80000) die("skip PHP 8 only");
+?>
+--FILE--
+<?php
+
+$imported = hdr_import(["ltv" => 0, "htv" => 0, "sf" => 0, "sk" => 0, "c" => []]);
+try {
+	$imported = hdr_import();
+} catch (ArgumentCountError $e) {
+	echo $e->getMessage()."\n";
+}
+
+$imported = hdr_import([]);
+$imported = hdr_import(["ltv" => -1]);
+$imported = hdr_import(["ltv" => 1, "htv" => -10]);
+$imported = hdr_import(["ltv" => 1, "htv" => 10, "sf" => -2]);
+$imported = hdr_import(["ltv" => 1, "htv" => 10, "sf" => 1, "c" => null]);
+$imported = hdr_import(["ltv" => 1, "htv" => 10, "sf" => 1, "b" => null]);
+$imported = hdr_import(["ltv" => 1, "htv" => 10, "sf" => 1, "b" => null, "c" => null]);
+--EXPECTF--
+Warning: hdr_import(): lowest_trackable_value (ltv) must be >= 1. in %s
+hdr_import() expects exactly 1 argument, 0 given
+
+Warning: hdr_import(): Missing counts (c) or bucket (b) key or not arrays. in %s
+
+Warning: hdr_import(): lowest_trackable_value (ltv) must be >= 1. in %s
+
+Warning: hdr_import(): highest_trackable_value (htv) must be >= 1. in %s
+
+Warning: hdr_import(): significant_figures (sf) must be 1, 2, or 3. in %s
+
+Warning: hdr_import(): Missing counts (c) or bucket (b) key or not arrays. in %s
+
+Warning: hdr_import(): Missing counts (c) or bucket (b) key or not arrays. in %s
+
+Warning: hdr_import(): Missing counts (c) or bucket (b) key or not arrays. in %s


### PR DESCRIPTION
Changes:
- drop all TSRMS macro
- add all arginfo for PHP 7
- add all arginfo for PHP 8 with type hinting

About the sub

Pros:
* easier to maintain
* generate both legacy and new data

Cons:
* requires PHP 8 for developer

