### PR TITLE
Fix for libhdr_histogram version 0.11.4

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -3,41 +3,57 @@ PHP_ARG_WITH(hdrhistogram,
     [  --with-hdrhistogram[=DIR]    Enable "hdrhistogram" extension support])
 
 if test "$PHP_HDRHISTOGRAM" != "no"; then
-    SEARCH_PATH="/usr/local /usr"
-    SEARCH_FOR="/include/hdr/hdr_histogram.h"  # you most likely want to change this
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
 
-    if test -r $PHP_HDRHISTOGRAM/$SEARCH_FOR; then
-        HDRHISTOGRAM_PATH=$PHP_HDRHISTOGRAM
-    else
-        AC_MSG_CHECKING([for hdrhistogram files in default path])
-        for i in $SEARCH_PATH ; do
-            if test -r $i/$SEARCH_FOR; then
-            HDRHISTOGRAM_PATH=$i
-            AC_MSG_RESULT(found in $i)
+    if test "$PHP_HDRHISTOGRAM" = "yes" -a -x "$PKG_CONFIG" && $PKG_CONFIG --exists hdr_histogram; then
+
+        AC_MSG_CHECKING([for hdrhistogram from pkg-config])
+        LIBHDR_CFLAGS=`$PKG_CONFIG hdr_histogram --cflags`
+        LIBHDR_LIBDIR=`$PKG_CONFIG hdr_histogram --libs`
+        LIBHDR_VERSON=`$PKG_CONFIG hdr_histogram --modversion`
+        AC_MSG_RESULT(found $LIBHDR_VERSON)
+        if $PKG_CONFIG hdr_histogram --atleast-version 0.11.4; then
+            AC_DEFINE(HAVE_HDRHISTOGRAM_0_11_4,1,[ ])
         fi
-        done
+        PHP_EVAL_LIBLINE($LIBHDR_LIBDIR, HDRHISTOGRAM_SHARED_LIBADD)
+        PHP_EVAL_INCLINE($LIBHDR_CFLAGS)
+    else
+        SEARCH_PATH="/usr/local /usr"
+        SEARCH_FOR="/include/hdr/hdr_histogram.h"  # you most likely want to change this
+
+        if test -r $PHP_HDRHISTOGRAM/$SEARCH_FOR; then
+            HDRHISTOGRAM_PATH=$PHP_HDRHISTOGRAM
+        else
+            AC_MSG_CHECKING([for hdrhistogram files in default path])
+            for i in $SEARCH_PATH ; do
+                if test -r $i/$SEARCH_FOR; then
+                HDRHISTOGRAM_PATH=$i
+                AC_MSG_RESULT(found in $i)
+            fi
+            done
+        fi
+
+        if test -z "$HDRHISTOGRAM_PATH"; then
+          AC_MSG_RESULT([not found])
+          AC_MSG_ERROR([Please reinstall the hdrhistogram library])
+        fi
+
+        PHP_ADD_INCLUDE($HDRHISTOGRAM_PATH/include)
+
+        LIBNAME=hdr_histogram
+        LIBSYMBOL=hdr_init
+
+        PHP_CHECK_LIBRARY($LIBNAME, $LIBSYMBOL,
+            [
+                PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $HDRHISTOGRAM_PATH/$PHP_LIBDIR, HDRHISTOGRAM_SHARED_LIBADD)
+                AC_DEFINE(HAVE_HDRHISTOGRAM,1,[ ])
+            ],[
+                AC_MSG_ERROR([wrong hdrhistogram lib version or lib not found])
+            ],[
+                -L$HDRHISTOGRAM_PATH/$PHP_LIBDIR
+            ]
+        )
     fi
-
-    if test -z "$HDRHISTOGRAM_PATH"; then
-      AC_MSG_RESULT([not found])
-      AC_MSG_ERROR([Please reinstall the hdrhistogram library])
-    fi
-
-    PHP_ADD_INCLUDE($HDRHISTOGRAM_PATH/include)
-
-    LIBNAME=hdr_histogram
-    LIBSYMBOL=hdr_init
-
-    PHP_CHECK_LIBRARY($LIBNAME, $LIBSYMBOL,
-        [
-            PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $HDRHISTOGRAM_PATH/$PHP_LIBDIR, HDRHISTOGRAM_SHARED_LIBADD)
-            AC_DEFINE(HAVE_HDRHISTOGRAM,1,[ ])
-        ],[
-            AC_MSG_ERROR([wrong hdrhistogram lib version or lib not found])
-        ],[
-            -L$HDRHISTOGRAM_PATH/$PHP_LIBDIR
-        ]
-    )
 
     PHP_SUBST(HDRHISTOGRAM_SHARED_LIBADD)
 

--- a/config.m4
+++ b/config.m4
@@ -12,6 +12,9 @@ if test "$PHP_HDRHISTOGRAM" != "no"; then
         LIBHDR_LIBDIR=`$PKG_CONFIG hdr_histogram --libs`
         LIBHDR_VERSON=`$PKG_CONFIG hdr_histogram --modversion`
         AC_MSG_RESULT(found $LIBHDR_VERSON)
+        if $PKG_CONFIG hdr_histogram --atleast-version 0.11.7; then
+            AC_DEFINE(HAVE_HDRHISTOGRAM_0_11_7,1,[ ])
+        fi
         if $PKG_CONFIG hdr_histogram --atleast-version 0.11.4; then
             AC_DEFINE(HAVE_HDRHISTOGRAM_0_11_4,1,[ ])
         fi

--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -67,7 +67,7 @@ zend_module_entry hdrhistogram_module_entry = {
     PHP_RINIT(hdrhistogram),               /* Request init callback */
     PHP_RSHUTDOWN(hdrhistogram),           /* Request shutdown callback */
     PHP_MINFO(hdrhistogram),               /* Module info callback */
-    HDR_VERSION,
+    PHP_HDR_HISTOGRAM_VERSION,
     STANDARD_MODULE_PROPERTIES
 };
 
@@ -118,8 +118,8 @@ PHP_MINFO_FUNCTION(hdrhistogram)
 {
 	php_info_print_table_start();
 
-	php_info_print_table_row(2, "hdrhistogram", "enabled");
-	php_info_print_table_row(2, "Extension version", HDR_VERSION);
+	php_info_print_table_row(2, "hdrhistogram support", "enabled");
+	php_info_print_table_row(2, "Extension version", PHP_HDR_HISTOGRAM_VERSION);
 #ifdef HDR_HISTOGRAM_VERSION
 	php_info_print_table_row(2, "Library version", HDR_HISTOGRAM_VERSION);
 #endif

--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -3,8 +3,12 @@
 #endif
 
 #include "php.h"
+#include "ext/standard/info.h"
 #include "hdr/hdr_histogram.h"
 #include "hdr/hdr_histogram_log.h"
+#ifdef HAVE_HDRHISTOGRAM_0_11_7
+#include "hdr/hdr_histogram_version.h"
+#endif
 #include "php_hdrhistogram.h"
 
 #if PHP_VERSION_ID < 80000
@@ -112,6 +116,13 @@ PHP_RSHUTDOWN_FUNCTION(hdrhistogram)
 
 PHP_MINFO_FUNCTION(hdrhistogram)
 {
+	php_info_print_table_start();
+
+	php_info_print_table_row(2, "hdrhistogram", "enabled");
+	php_info_print_table_row(2, "Extension version", HDR_VERSION);
+#ifdef HDR_HISTOGRAM_VERSION
+	php_info_print_table_row(2, "Library version", HDR_HISTOGRAM_VERSION);
+#endif
 }
 
 PHP_FUNCTION(hdr_init)

--- a/php_hdrhistogram.h
+++ b/php_hdrhistogram.h
@@ -5,7 +5,7 @@
 
 extern zend_module_entry hdrhistogram_module_entry;
 #define phpext_hdrhistogram_ptr &hdrhistogram_module_entry
-#define HDR_VERSION "0.4.2"
+#define PHP_HDR_HISTOGRAM_VERSION "0.4.2"
 
 PHP_MINIT_FUNCTION(hdrhistogram);
 PHP_MSHUTDOWN_FUNCTION(hdrhistogram);


### PR DESCRIPTION
As version 0.11.4 add a pkg-config file (which is broken for now see #https://github.com/HdrHistogram/HdrHistogram_c/pull/104) this PR uses it and set a flag to allow conditional in code

Everywhere new name is used (lowest_discernible_value), old name is only used for struct access (when old version is used) and for error message (to not break tests)

Test suite passes with 0.11.2 and 0.11.4

P.S. build without pkg-config may be broken, but pkg-config is now the preferred way to use libraries.