### PR TITLE
Improve configure checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
 
         echo "version=$(php -dextension=.libs/hdrhistogram.so -r "echo phpversion('hdrhistogram');")" >> $GITHUB_OUTPUT
 
+        php -dextension=.libs/hdrhistogram.so -i
+
     - name: run-tests.php for hdrhistogram ${{ steps.hdrhistogram-version.outputs.version }}
       timeout-minutes: 5
       run: |

--- a/config.m4
+++ b/config.m4
@@ -12,9 +12,6 @@ if test "$PHP_HDRHISTOGRAM" != "no"; then
         LIBHDR_LIBDIR=`$PKG_CONFIG hdr_histogram --libs`
         LIBHDR_VERSON=`$PKG_CONFIG hdr_histogram --modversion`
         AC_MSG_RESULT(found $LIBHDR_VERSON)
-        if $PKG_CONFIG hdr_histogram --atleast-version 0.11.7; then
-            AC_DEFINE(HAVE_HDRHISTOGRAM_0_11_7,1,[ ])
-        fi
         if $PKG_CONFIG hdr_histogram --atleast-version 0.11.4; then
             AC_DEFINE(HAVE_HDRHISTOGRAM_0_11_4,1,[ ])
         fi
@@ -56,6 +53,11 @@ if test "$PHP_HDRHISTOGRAM" != "no"; then
             ]
         )
     fi
+
+    old_CPPFLAGS=$CPPFLAGS
+    CPPFLAGS="$CPPFLAGS $INCLUDES"
+    AC_CHECK_HEADERS([hdr/hdr_histogram_version.h])
+    CPPFLAGS=$old_CPPFLAGS
 
     PHP_SUBST(HDRHISTOGRAM_SHARED_LIBADD)
 

--- a/config.m4
+++ b/config.m4
@@ -49,7 +49,6 @@ if test "$PHP_HDRHISTOGRAM" != "no"; then
         PHP_CHECK_LIBRARY($LIBNAME, $LIBSYMBOL,
             [
                 PHP_ADD_LIBRARY_WITH_PATH($LIBNAME, $HDRHISTOGRAM_PATH/$PHP_LIBDIR, HDRHISTOGRAM_SHARED_LIBADD)
-                AC_DEFINE(HAVE_HDRHISTOGRAM,1,[ ])
             ],[
                 AC_MSG_ERROR([wrong hdrhistogram lib version or lib not found])
             ],[

--- a/config.m4
+++ b/config.m4
@@ -1,6 +1,6 @@
 PHP_ARG_WITH(hdrhistogram,
     [if to enable the "hdrhistogram" extension"],
-    [  --with-hdrhistogram[=DIR]    Enable "hdrhistogram" extension support])
+    [  --with-hdrhistogram[=DIR] Enable "hdrhistogram" extension support])
 
 if test "$PHP_HDRHISTOGRAM" != "no"; then
     AC_PATH_PROG(PKG_CONFIG, pkg-config, no)

--- a/config.m4
+++ b/config.m4
@@ -1,5 +1,5 @@
 PHP_ARG_WITH(hdrhistogram,
-    [if to enable the "hdrhistogram" extension"],
+    [if to enable the "hdrhistogram" extension],
     [  --with-hdrhistogram[=DIR] Enable "hdrhistogram" extension support])
 
 if test "$PHP_HDRHISTOGRAM" != "no"; then

--- a/config.m4
+++ b/config.m4
@@ -12,9 +12,6 @@ if test "$PHP_HDRHISTOGRAM" != "no"; then
         LIBHDR_LIBDIR=`$PKG_CONFIG hdr_histogram --libs`
         LIBHDR_VERSON=`$PKG_CONFIG hdr_histogram --modversion`
         AC_MSG_RESULT(found $LIBHDR_VERSON)
-        if $PKG_CONFIG hdr_histogram --atleast-version 0.11.4; then
-            AC_DEFINE(HAVE_HDRHISTOGRAM_0_11_4,1,[ ])
-        fi
         PHP_EVAL_LIBLINE($LIBHDR_LIBDIR, HDRHISTOGRAM_SHARED_LIBADD)
         PHP_EVAL_INCLINE($LIBHDR_CFLAGS)
     else
@@ -57,6 +54,13 @@ if test "$PHP_HDRHISTOGRAM" != "no"; then
     old_CPPFLAGS=$CPPFLAGS
     CPPFLAGS="$CPPFLAGS $INCLUDES"
     AC_CHECK_HEADERS([hdr/hdr_histogram_version.h])
+    CPPFLAGS=$old_CPPFLAGS
+
+    old_CPPFLAGS=$CPPFLAGS
+    CPPFLAGS="$CPPFLAGS $INCLUDES"
+    AC_CHECK_MEMBER([struct hdr_histogram.lowest_discernible_value], [
+        AC_DEFINE(HAVE_HDR_HISTOGRAM_LOWEST_DISCERNIBLE_VALUE, 1, [ ])
+    ], [], [#include "hdr/hdr_histogram.h"])
     CPPFLAGS=$old_CPPFLAGS
 
     PHP_SUBST(HDRHISTOGRAM_SHARED_LIBADD)

--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -478,7 +478,7 @@ PHP_FUNCTION(hdr_add)
     hdra = php_hdrhistogram_histogram_from_object(Z_OBJ_P(a))->histogram;
     hdrb = php_hdrhistogram_histogram_from_object(Z_OBJ_P(b))->histogram;
 
-#ifdef HAVE_HDRHISTOGRAM_0_11_4
+#ifdef HAVE_HDR_HISTOGRAM_LOWEST_DISCERNIBLE_VALUE
     res = hdr_init(hdra->lowest_discernible_value, hdra->highest_trackable_value, hdra->significant_figures, &hdr_new);
 #else
     res = hdr_init(hdra->lowest_trackable_value, hdra->highest_trackable_value, hdra->significant_figures, &hdr_new);
@@ -625,7 +625,7 @@ PHP_FUNCTION(hdr_export)
     array_init(return_value);
 
 
-#ifdef HAVE_HDRHISTOGRAM_0_11_4
+#ifdef HAVE_HDR_HISTOGRAM_LOWEST_DISCERNIBLE_VALUE
     if (hdr->lowest_discernible_value > 1) {
         add_assoc_long(return_value, "ltv", hdr->lowest_discernible_value);
     }

--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -8,7 +8,7 @@
 #include "Zend/zend_interfaces.h"
 #include "hdr/hdr_histogram.h"
 #include "hdr/hdr_histogram_log.h"
-#ifdef HAVE_HDRHISTOGRAM_0_11_7
+#ifdef HAVE_HDR_HDR_HISTOGRAM_VERSION_H
 #include "hdr/hdr_histogram_version.h"
 #endif
 #include "php_hdrhistogram.h"


### PR DESCRIPTION
This now correctly detects `lowest_discernible_value` without `pkg-config`. See #15:

> P.S. build without pkg-config may be broken, but pkg-config is now the preferred way to use libraries.