### PR TITLE
Fix build on C89 only compiler

### DIFF
--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -673,7 +673,8 @@ PHP_FUNCTION(hdr_export)
 
     int64_t found = 0;
     zend_long skipped = 0;
-    for (int32_t i = 0; i < hdr->counts_len; i++) {
+    int32_t i;
+    for (i = 0; i < hdr->counts_len; i++) {
         if (found >= hdr->total_count) {
             break;
         }

--- a/hdrhistogram.c
+++ b/hdrhistogram.c
@@ -775,6 +775,7 @@ PHP_FUNCTION(hdr_import)
         zend_ulong num_key;
         int bucket = 0;
         ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(value), num_key, key, item) {
+            (void)num_key;
             if (!key && bucket < hdr->counts_len) {
                 convert_to_long_ex(item);
                 if (Z_LVAL_P(item) > 0) {


### PR DESCRIPTION
Minor fix, BTW only affects old GCC, so only old distro such as EL-7 which is going to be EOL in a few weeks
