### PR TITLE
Migrate the extended CI builds to PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,32 +22,32 @@ jobs:
             debug: true
             zts: false
             static: false
-          - phpVersion: "8.3"
-            hdrVersion: main
-            os: ubuntu-24.04
-            debug: true
-            zts: false
-            static: false
-          - phpVersion: "8.3"
+          - phpVersion: "8.4"
             hdrVersion: main
             os: ubuntu-24.04
             debug: sanitize
             zts: false
             static: false
-          - phpVersion: "8.3"
+          - phpVersion: "8.4"
             hdrVersion: main
             os: ubuntu-24.04
             debug: true
             zts: true
             static: false
-          - phpVersion: "8.3"
+          - phpVersion: "8.4"
             hdrVersion: main
             os: ubuntu-24.04
             debug: true
             zts: false
             static: true
-          - phpVersion: "8.3"
+          - phpVersion: "8.4"
             hdrVersion: "0.9.8"
+            os: ubuntu-24.04
+            debug: true
+            zts: false
+            static: false
+          - phpVersion: "8.3"
+            hdrVersion: main
             os: ubuntu-24.04
             debug: true
             zts: false


### PR DESCRIPTION
Now that PHP 8.4 is the latest stable version, the extended CI builds for non-(debug+NTS) configurations should be migrated to it.